### PR TITLE
Change default timeout value for pings

### DIFF
--- a/src/proto/mod.rs
+++ b/src/proto/mod.rs
@@ -156,7 +156,7 @@ where
             timer: tokio::timer::Delay::new(
                 time::Instant::now() + time::Duration::from_secs(86_400),
             ),
-            timeout: time::Duration::new(0, 0),
+            timeout: time::Duration::new(86_400, 0),
             outbox: Vec::new(),
             outstart: 0,
             inbox: Vec::new(),


### PR DESCRIPTION
When the default timeout value is 0, the library will start sending
pings immediately after a Connect request is sent, since the timer is
reset to "time::Instant::now() + self.timeout" whenever a write occurs.