### PR TITLE
Add methods for operating on Acls

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -36,6 +36,11 @@ pub enum SetData {
         /// The expected node version.
         expected: i32,
     },
+
+    /// The target node's permission does not accept data modification or requires different
+    /// authentication to be altered.
+    #[fail(display = "insuficient authentication")]
+    NoAuth,
 }
 
 /// Errors that may cause a create request to fail.
@@ -64,4 +69,31 @@ pub enum GetAcl {
     /// No node exists with the given `path`.
     #[fail(display = "target node does not exist")]
     NoNode,
+}
+
+/// Errors that may cause a `set_acl` request to fail.
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Fail)]
+pub enum SetAcl {
+    /// No node exists with the given `path`.
+    #[fail(display = "target node does not exist")]
+    NoNode,
+
+    /// The target node has a different version than was specified by the call to `set_acl`.
+    #[fail(
+        display = "target node has different version than expected ({})",
+        expected
+    )]
+    BadVersion {
+        /// The expected node version.
+        expected: i32,
+    },
+
+    /// The given ACL is invalid.
+    #[fail(display = "the given ACL is invalid")]
+    InvalidAcl,
+
+    /// The target node's permission does not accept acl modification or requires different
+    /// authentication to be altered.
+    #[fail(display = "insuficient authentication")]
+    NoAuth,
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -94,6 +94,6 @@ pub enum SetAcl {
 
     /// The target node's permission does not accept acl modification or requires different
     /// authentication to be altered.
-    #[fail(display = "insuficient authentication")]
+    #[fail(display = "insufficient authentication")]
     NoAuth,
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -57,3 +57,11 @@ pub enum Create {
     #[fail(display = "the given ACL is invalid")]
     InvalidAcl,
 }
+
+/// Errors that may cause a `get_acl` request to fail.
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Fail)]
+pub enum GetAcl {
+    /// No node exists with the given `path`.
+    #[fail(display = "target node does not exist")]
+    NoNode,
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -520,7 +520,8 @@ impl ZooKeeper {
             .map(move |r| (self, r))
     }
 
-    /// Return the ACL and Stat of the node at the given `path`.
+    /// Return the [ACL](https://zookeeper.apache.org/doc/current/zookeeperProgrammers.html#sc_ZooKeeperAccessControl)
+    /// and Stat of the node at the given `path`.
     ///
     /// If no node exists for the given path, the returned future resolves with an error of
     /// [`error::GetAcl::NoNode`].
@@ -543,7 +544,8 @@ impl ZooKeeper {
             .map(move |r| (self, r))
     }
 
-    /// Set the ACL for the node of the given `path`.
+    /// Set the [ACL](https://zookeeper.apache.org/doc/current/zookeeperProgrammers.html#sc_ZooKeeperAccessControl)
+    /// for the node of the given `path`.
     ///
     /// The call will succeed if such a node exists and the given `version` matches the ACL version
     /// of the node. On success, the updated [`Stat`] of the node is returned.

--- a/src/proto/request.rs
+++ b/src/proto/request.rs
@@ -41,6 +41,9 @@ pub(crate) enum Request {
         path: String,
         watch: Watch,
     },
+    GetAcl {
+        path: String,
+    },
 }
 
 #[derive(Clone, Copy, Debug, Hash, Eq, PartialEq, Ord, PartialOrd)]
@@ -53,8 +56,8 @@ pub(super) enum OpCode {
     Exists = 3,
     GetData = 4,
     SetData = 5,
-    GetACL = 6,
-    SetACL = 7,
+    GetAcl = 6,
+    SetAcl = 7,
     GetChildren = 8,
     Synchronize = 9,
     Ping = 11,
@@ -177,6 +180,10 @@ impl Request {
                 write_list(&mut *buffer, acl)?;
                 buffer.write_i32::<BigEndian>(mode as i32)?;
             }
+            Request::GetAcl { ref path } => {
+                buffer.write_i32::<BigEndian>(OpCode::GetAcl as i32)?;
+                path.write_to(&mut *buffer)?;
+            }
         }
         Ok(())
     }
@@ -190,6 +197,7 @@ impl Request {
             Request::GetChildren { .. } => OpCode::GetChildren,
             Request::SetData { .. } => OpCode::SetData,
             Request::GetData { .. } => OpCode::GetData,
+            Request::GetAcl { .. } => OpCode::GetAcl,
         }
     }
 }

--- a/src/proto/response.rs
+++ b/src/proto/response.rs
@@ -142,7 +142,9 @@ impl Response {
                 password: reader.read_buffer()?,
                 read_only: reader.read_u8()? != 0,
             }),
-            OpCode::Exists | OpCode::SetData => Ok(Response::Stat(Stat::read_from(&mut reader)?)),
+            OpCode::Exists | OpCode::SetData | OpCode::SetACL => {
+                Ok(Response::Stat(Stat::read_from(&mut reader)?))
+            }
             OpCode::GetData => Ok(Response::GetData {
                 bytes: reader.read_buffer()?,
                 stat: Stat::read_from(&mut reader)?,
@@ -150,7 +152,7 @@ impl Response {
             OpCode::Delete => Ok(Response::Empty),
             OpCode::GetChildren => Ok(Response::Strings(Vec::<String>::read_from(&mut reader)?)),
             OpCode::Create => Ok(Response::String(reader.read_string()?)),
-            OpCode::GetAcl => Ok(Response::GetAcl {
+            OpCode::GetACL => Ok(Response::GetAcl {
                 acl: Vec::<Acl>::read_from(&mut reader)?,
                 stat: Stat::read_from(&mut reader)?,
             }),

--- a/src/types/acl.rs
+++ b/src/types/acl.rs
@@ -143,7 +143,7 @@ mod tests {
 /// not recursive: If `/path` is only readable by a single user, but `/path/sub` is world-readable,
 /// then anyone will be able to read `/path/sub`.
 ///
-/// See the [ZooKeeper Programmer's Guide](https://zookeeper.apache.org/doc/trunk/zookeeperProgrammers.html#sc_ZooKeeperAccessControl)
+/// See the [ZooKeeper Programmer's Guide](https://zookeeper.apache.org/doc/current/zookeeperProgrammers.html#sc_ZooKeeperAccessControl)
 /// for more information.
 #[derive(Clone, Debug, PartialEq)]
 pub struct Acl {


### PR DESCRIPTION
Added the two methods needed for retrieving and updating Acl information on a node, `get_acl` and `set_acl`, see [ZooKeeper access control using ACLs](https://zookeeper.apache.org/doc/r3.1.2/zookeeperProgrammers.html#sc_ZooKeeperAccessControl) and #11.
