### PR TITLE
Run tests in travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,32 @@
+language: rust
+rust:
+  - stable
+  - beta
+  - nightly
+matrix:
+  allow_failures:
+    - rust: nightly
+  fast_finish: true
+
+jdk:
+  - oraclejdk9
+
+sudo: false
+
+branches:
+  only:
+    - master
+
+before_install:
+  - export APACHE_MIRROR=http://apache.osuosl.org
+  - wget -O zookeeper.tar.gz ${APACHE_MIRROR}/zookeeper/zookeeper-${ZOOKEEPER_VERSION}/zookeeper-${ZOOKEEPER_VERSION}.tar.gz
+  - mkdir zookeeper
+  - tar -zxvf zookeeper.tar.gz -C zookeeper --strip-components 1
+
+before_script:
+  - ./travis/before_script.sh
+
+env:
+  matrix:
+    - ZOOKEEPER_VERSION=3.4.12
+    - ZOOKEEPER_VERSION=3.4.10

--- a/travis/before_script.sh
+++ b/travis/before_script.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -x
+
+mkdir /tmp/data
+echo -e "tickTime=2000\ndataDir=/tmp/data\nclientPort=2181" > zookeeper/conf/zoo.cfg
+./zookeeper/bin/zkServer.sh start


### PR DESCRIPTION
Addresses #3

Runs the test suite in travis for 2 zookeeper versions currently and 3 rust version (stable, beta, nightly). Rust nightly failures are ignored.

Opted for the download ZK and run it on each run as seemed simpler than using curator etc. I did try auto selecting an apache mirror based on https://stackoverflow.com/questions/21534797/finding-the-closest-apache-software-foundation-mirror-programatically but I think some of the suggested mirrors might be blocked for access from Travis as I got 403's even though they worked fine from my machine.